### PR TITLE
Create a module for common repository methods

### DIFF
--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -1,6 +1,8 @@
 require_relative 'merchant'
+require_relative 'repo_methods'
 
 class MerchantRepository
+  include RepoMethods
   def initialize(merchant_data)
     @merchant_rows ||= build_merchant(merchant_data)
     @repo = @merchant_rows #shops = an array of merchants, might change this name

--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -14,22 +14,6 @@ class MerchantRepository
     end
   end
 
-  def all
-    @repo
-  end
-
-  def find_by_id(id)
-    @repo.find do |merchant|
-      merchant.id == id
-    end
-  end
-
-  def find_by_name(name)
-    @repo.find do |merchant| #rubocop wants the line below
-      merchant.name.casecmp(name).zero? # if case-insensitive returns 0, = the same name
-    end
-  end
-
   def find_all_by_name(fragment)
     @repo.find_all do |merchant|
       merchant.name.downcase.include?(fragment.downcase)
@@ -48,16 +32,6 @@ class MerchantRepository
     merchant
   end
 
-  def create_id
-    find_highest_id.id + 1
-  end
-
-  def find_highest_id
-    @repo.max_by do |merchant|
-      merchant.id
-    end
-  end
-
   def update(id, attributes)
     merchant = find_by_id(id)
     return if merchant.nil?
@@ -66,15 +40,4 @@ class MerchantRepository
     merchant
   end
 
-  def delete(id)
-    merchant = @repo.find_index do |merchant|
-      merchant.id == id
-    end
-    return if merchant.nil?
-    @repo.delete_at(merchant)
-  end
-
-  def inspect
-    "#<#{self.class} #{@repo.size} rows>"
-  end
 end

--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -3,7 +3,7 @@ require_relative 'merchant'
 class MerchantRepository
   def initialize(merchant_data)
     @merchant_rows ||= build_merchant(merchant_data)
-    @merchants = @merchant_rows #shops = an array of merchants, might change this name
+    @repo = @merchant_rows #shops = an array of merchants, might change this name
   end
 
   def build_merchant(merchant_data)
@@ -13,23 +13,23 @@ class MerchantRepository
   end
 
   def all
-    @merchants
+    @repo
   end
 
   def find_by_id(id)
-    @merchants.find do |merchant|
+    @repo.find do |merchant|
       merchant.id == id
     end
   end
 
   def find_by_name(name)
-    @merchants.find do |merchant| #rubocop wants the line below
+    @repo.find do |merchant| #rubocop wants the line below
       merchant.name.casecmp(name).zero? # if case-insensitive returns 0, = the same name
     end
   end
 
   def find_all_by_name(fragment)
-    @merchants.find_all do |merchant|
+    @repo.find_all do |merchant|
       merchant.name.downcase.include?(fragment.downcase)
     end
   end
@@ -42,7 +42,7 @@ class MerchantRepository
       created_at: Time.now,
       updated_at: Time.now,
       )
-    @merchants << merchant
+    @repo << merchant
     merchant
   end
 
@@ -51,7 +51,7 @@ class MerchantRepository
   end
 
   def find_highest_id
-    @merchants.max_by do |merchant|
+    @repo.max_by do |merchant|
       merchant.id
     end
   end
@@ -65,14 +65,14 @@ class MerchantRepository
   end
 
   def delete(id)
-    merchant = @merchants.find_index do |merchant|
+    merchant = @repo.find_index do |merchant|
       merchant.id == id
     end
     return if merchant.nil?
-    @merchants.delete_at(merchant)
+    @repo.delete_at(merchant)
   end
 
   def inspect
-    "#<#{self.class} #{@merchants.size} rows>"
+    "#<#{self.class} #{@repo.size} rows>"
   end
 end

--- a/lib/repo_methods.rb
+++ b/lib/repo_methods.rb
@@ -1,0 +1,4 @@
+module RepoMethods
+
+
+end

--- a/lib/repo_methods.rb
+++ b/lib/repo_methods.rb
@@ -1,4 +1,46 @@
 module RepoMethods
 
+  def all
+    @repo
+  end
 
+  def find_by_id(id)
+    @repo.find do |object|
+      object.id == id
+    end
+  end
+
+  def find_by_name(name)
+    @repo.find do |object|
+      object.name.casecmp(name).zero? # if case-insensitive returns 0, = the same name
+    end
+  end
+
+  def find_all_by_merchant_id(merchant_id)
+    @repo.find_all do |object|
+      object.merchant_id == merchant_id
+    end
+  end
+
+  def create_id
+    find_highest_id.id + 1
+  end
+
+  def find_highest_id
+    @repo.max_by do |object|
+      object.id
+    end
+  end
+
+  def delete(id)
+    object = @repo.find_index do |object|
+      object.id == id
+    end
+    return if object.nil?
+    @repo.delete_at(object)
+  end
+
+  def inspect
+    "#<#{self.class} #{@repo.size} rows>"
+  end
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -3,8 +3,10 @@ require_relative 'merchant_repository'
 require_relative 'item_repository'
 require_relative 'invoice_repository'
 require_relative 'sales_analyst'
+require_relative 'repo_methods'
 
 class SalesEngine
+  include RepoMethods
   attr_reader     :file_path
 
   def self.from_csv(file_path)


### PR DESCRIPTION
This creates a module, RepoMethods, to hold methods that prior to now were duplicated across multiple repository classes (MerchantRepository, ItemRepository, & InvoiceRepository so far). This copies these methods into the new RepoMethods module. It also removes them from MerchantRepository, and requires and includes RepoMethods in MerchantRepository. ItemRepository & InvoiceRepository will be done in a separate pull request. Spec harness runs clean. 