### PR TITLE
Resolve robo cop errors in tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,7 @@ Style/FrozenStringLiteralComment:
 # remove missing top-level class documentation comments
 Style/Documentation:
   Enabled: false
+
+# remove use underscores as a decimal mark & separate every 3 numbers with them
+Style/NumericLiterals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 rubocop:
   config_file: .rubocop.yml
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 rubocop:
   config_file: .rubocop.yml
 
+# remove missing frozen string literal comments
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# remove missing top-level class documentation comments
+Style/Documentation:
   Enabled: false

--- a/test/customer_repository_test.rb
+++ b/test/customer_repository_test.rb
@@ -1,6 +1,6 @@
-require_relative '../lib/customer_repository'
-require_relative '../lib/customer'
 require_relative './test_helper'
+require './lib/customer_repository'
+require './lib/customer'
 
 class CustomerRepositoryTest < Minitest::Test
   def setup

--- a/test/customer_repository_test.rb
+++ b/test/customer_repository_test.rb
@@ -53,12 +53,12 @@ class CustomerRepositoryTest < Minitest::Test
   end
 
   def test_it_can_find_a_customer_by_a_valid_first_name
-    customer_1 = @customer_repository.find_all_by_first_name('Jane')
-    assert_equal Customer, customer_1[0].class
-    assert_equal 'Jane', customer_1[0].first_name
+    customer_one = @customer_repository.find_all_by_first_name('Jane')
+    assert_equal Customer, customer_one[0].class
+    assert_equal 'Jane', customer_one[0].first_name
 
-    customer_2 = @customer_repository.find_all_by_first_name('Jerry')
-    assert_equal 2, customer_2.count
+    customer_two = @customer_repository.find_all_by_first_name('Jerry')
+    assert_equal 2, customer_two.count
   end
 
   def test_it_returns_nil_if_customer_first_name_is_invalid
@@ -67,12 +67,12 @@ class CustomerRepositoryTest < Minitest::Test
   end
 
   def test_it_can_find_a_customer_by_a_valid_last_name
-    customer_1 = @customer_repository.find_all_by_last_name('Don')
-    assert_equal Customer, customer_1[0].class
-    assert_equal 'Don', customer_1[0].last_name
+    customer_one = @customer_repository.find_all_by_last_name('Don')
+    assert_equal Customer, customer_one[0].class
+    assert_equal 'Don', customer_one[0].last_name
 
-    customer_2 = @customer_repository.find_all_by_last_name('Doe')
-    assert_equal 3, customer_2.count
+    customer_two = @customer_repository.find_all_by_last_name('Doe')
+    assert_equal 3, customer_two.count
   end
 
   def test_it_returns_nil_if_customer_last_name_is_invalid

--- a/test/customer_repository_test.rb
+++ b/test/customer_repository_test.rb
@@ -94,8 +94,7 @@ class CustomerRepositoryTest < Minitest::Test
     attributes = {  first_name: 'Juan',
                     last_name: 'Don',
                     created_at: '2010-12-10',
-                    updated_at: '2011-12-04'
-                  }
+                    updated_at: '2011-12-04' }
     customer = @customer_repository.create(attributes)
     assert_equal 'Juan', customer.first_name
     assert_equal 'Don', customer.last_name
@@ -115,13 +114,12 @@ class CustomerRepositoryTest < Minitest::Test
   end
 
   def test_it_can_delete_customer
-    id = 2
+    customer_id = 2
+    @customer_repository.delete(customer_id)
+    expected_one = @customer_repository.find_all_by_first_name('John')
+    expected_two = @customer_repository.find_by_id(customer_id)
 
-    customer = @customer_repository.delete(id)
-    expected_1 = @customer_repository.find_all_by_first_name('John')
-    expected_2 = @customer_repository.find_by_id(id)
-
-    assert_equal [], expected_1
-    assert_nil expected_2
+    assert_equal [], expected_one
+    assert_nil expected_two
   end
 end

--- a/test/customer_repository_test.rb
+++ b/test/customer_repository_test.rb
@@ -106,7 +106,7 @@ class CustomerRepositoryTest < Minitest::Test
       first_name: 'Greg'
     }
     id = 2
-    customer = @customer_repository.update(id, attributes)
+    @customer_repository.update(id, attributes)
     expected = @customer_repository.find_by_id(id)
     assert_equal 'Greg', expected.first_name
     expected = @customer_repository.find_all_by_first_name('John')

--- a/test/customer_repository_test.rb
+++ b/test/customer_repository_test.rb
@@ -5,27 +5,34 @@ require_relative './test_helper'
 class CustomerRepositoryTest < Minitest::Test
   def setup
     @customers =
-      [{id: 1,
+    [{
+      id: 1,
       first_name: 'Jane',
       last_name: 'Doe',
       created_at: '2010-12-10',
-      updated_at: '2011-12-04'},
-      {id: 2,
-      first_name: 'John',
-      last_name: 'Doe',
-      created_at: '2009-05-30',
-      updated_at: '2010-08-29'},
-      {id: 3,
-      first_name: 'Jerry',
-      last_name: 'Doe',
-      created_at: '2010-03-30',
-      updated_at: '2013-01-21'},
-      {id: 4,
-      first_name: 'Jerry',
-      last_name: 'Don',
-      created_at: '2010-03-30',
-      updated_at: '2013-01-21'}
-    ]
+      updated_at: '2011-12-04'
+    },
+     {
+       id: 2,
+       first_name: 'John',
+       last_name: 'Doe',
+       created_at: '2009-05-30',
+       updated_at: '2010-08-29'
+    },
+     {
+       id: 3,
+       first_name: 'Jerry',
+       last_name: 'Doe',
+       created_at: '2010-03-30',
+       updated_at: '2013-01-21'
+    },
+     {
+        id: 4,
+        first_name: 'Jerry',
+        last_name: 'Don',
+        created_at: '2010-03-30',
+        updated_at: '2013-01-21'
+      }]
 
     @customer_repository = CustomerRepository.new(@customers)
   end

--- a/test/customer_repository_test.rb
+++ b/test/customer_repository_test.rb
@@ -5,34 +5,26 @@ require_relative './test_helper'
 class CustomerRepositoryTest < Minitest::Test
   def setup
     @customers =
-    [{
-      id: 1,
-      first_name: 'Jane',
-      last_name: 'Doe',
-      created_at: '2010-12-10',
-      updated_at: '2011-12-04'
-    },
-     {
-       id: 2,
-       first_name: 'John',
-       last_name: 'Doe',
-       created_at: '2009-05-30',
-       updated_at: '2010-08-29'
-    },
-     {
-       id: 3,
-       first_name: 'Jerry',
-       last_name: 'Doe',
-       created_at: '2010-03-30',
-       updated_at: '2013-01-21'
-    },
-     {
-        id: 4,
-        first_name: 'Jerry',
-        last_name: 'Don',
-        created_at: '2010-03-30',
-        updated_at: '2013-01-21'
-      }]
+      [{  id: 1,
+          first_name: 'Jane',
+          last_name: 'Doe',
+          created_at: '2010-12-10',
+          updated_at: '2011-12-04' },
+       {   id: 2,
+           first_name: 'John',
+           last_name: 'Doe',
+           created_at: '2009-05-30',
+           updated_at: '2010-08-29' },
+       {   id: 3,
+           first_name: 'Jerry',
+           last_name: 'Doe',
+           created_at: '2010-03-30',
+           updated_at: '2013-01-21' },
+       {   id: 4,
+           first_name: 'Jerry',
+           last_name: 'Don',
+           created_at: '2010-03-30',
+           updated_at: '2013-01-21' }]
 
     @customer_repository = CustomerRepository.new(@customers)
   end

--- a/test/customer_test.rb
+++ b/test/customer_test.rb
@@ -3,15 +3,11 @@ require './lib/customer'
 
 class CustomerTest < Minitest::Test
   def test_it_exists
-    customer = Customer.new(
-      {
-        :id => 5,
-        :first_name => "Jane",
-        :last_name => "Doe",
-        :created_at => "2010-12-10",
-        :updated_at => "2011-12-04"
-        }
-      )
+    customer = Customer.new(id: 5,
+                            first_name: 'Jane',
+                            last_name: 'Doe',
+                            created_at: '2010-12-10',
+                            updated_at: '2011-12-04')
 
     assert_instance_of Customer, customer
   end
@@ -20,16 +16,16 @@ class CustomerTest < Minitest::Test
     customer = Customer.new(
       {
         :id => 5,
-        :first_name => "Jane",
-        :last_name => "Doe",
-        :created_at => "2010-12-10",
-        :updated_at => "2011-12-04"
+        :first_name => 'Jane',
+        :last_name => 'Doe',
+        :created_at => '2010-12-10',
+        :updated_at => '2011-12-04'
         }
       )
 
     assert_equal 5, customer.id
-    assert_equal "Jane", customer.first_name
-    assert_equal "Doe", customer.last_name
+    assert_equal 'Jane', customer.first_name
+    assert_equal 'Doe', customer.last_name
     assert_equal Time, customer.created_at.class
     assert_equal Time, customer.updated_at.class
   end

--- a/test/customer_test.rb
+++ b/test/customer_test.rb
@@ -13,15 +13,11 @@ class CustomerTest < Minitest::Test
   end
 
   def test_it_has_attributes
-    customer = Customer.new(
-      {
-        :id => 5,
-        :first_name => 'Jane',
-        :last_name => 'Doe',
-        :created_at => '2010-12-10',
-        :updated_at => '2011-12-04'
-        }
-      )
+    customer = Customer.new(id: 5,
+                            first_name: 'Jane',
+                            last_name: 'Doe',
+                            created_at: '2010-12-10',
+                            updated_at: '2011-12-04')
 
     assert_equal 5, customer.id
     assert_equal 'Jane', customer.first_name
@@ -29,5 +25,4 @@ class CustomerTest < Minitest::Test
     assert_equal Time, customer.created_at.class
     assert_equal Time, customer.updated_at.class
   end
-
 end

--- a/test/invoice_item_repository_test.rb
+++ b/test/invoice_item_repository_test.rb
@@ -1,6 +1,6 @@
-require_relative '../lib/invoice_item_repository'
-require_relative '../lib/invoice_item'
 require_relative './test_helper'
+require './lib/invoice_item_repository'
+require './lib/invoice_item'
 
 class InvoiceItemRepositoryTest < Minitest::Test
   def setup

--- a/test/invoice_item_repository_test.rb
+++ b/test/invoice_item_repository_test.rb
@@ -5,29 +5,27 @@ require './lib/invoice_item'
 class InvoiceItemRepositoryTest < Minitest::Test
   def setup
     @invoice_items =
-    [
-      { id: 1,
-        item_id: 263519841,
-        invoice_id: 1,
-        quantity: 5,
-        unit_price: 13635,
-        created_at: '2001-01-01 14:54:09 UTC',
-        updated_at: '2011-01-01 14:54:09 UTC'},
-      { id: 2,
-        item_id: 263519842,
-        invoice_id: 2,
-        quantity: 2,
-        unit_price: 23635,
-        created_at: '2002-02-02 14:54:09 UTC',
-        updated_at: '2012-02-02 14:54:09 UTC'},
-      { id: 3,
-        item_id: 263519843,
-        invoice_id: 3,
-        quantity: 3,
-        unit_price: 33635,
-        created_at: '2003-03-03 14:54:09 UTC',
-        updated_at: '2013-03-03 14:54:09 UTC'}
-    ]
+      [{  id: 1,
+          item_id: 263519841,
+          invoice_id: 1,
+          quantity: 5,
+          unit_price: 13635,
+          created_at: '2001-01-01 14:54:09 UTC',
+          updated_at: '2011-01-01 14:54:09 UTC' },
+       {  id: 2,
+          item_id: 263519842,
+          invoice_id: 2,
+          quantity: 2,
+          unit_price: 23635,
+          created_at: '2002-02-02 14:54:09 UTC',
+          updated_at: '2012-02-02 14:54:09 UTC' },
+       {  id: 3,
+          item_id: 263519843,
+          invoice_id: 3,
+          quantity: 3,
+          unit_price: 33635,
+          created_at: '2003-03-03 14:54:09 UTC',
+          updated_at: '2013-03-03 14:54:09 UTC' }]
     @iir = InvoiceItemRepository.new(@invoice_items)
   end
 

--- a/test/invoice_item_repository_test.rb
+++ b/test/invoice_item_repository_test.rb
@@ -43,12 +43,14 @@ class InvoiceItemRepositoryTest < Minitest::Test
 
   def test_it_can_find_an_invoice_item_by_a_valid_id
     item_invoice = @iir.find_by_id(1)
+
     assert_instance_of InvoiceItem, item_invoice
     assert_equal 1, item_invoice.id
   end
 
   def test_it_returns_nil_if_invoice_id_is_invalid
     invoice = @iir.find_by_id('invalid')
+
     assert_nil invoice
   end
 
@@ -56,6 +58,7 @@ class InvoiceItemRepositoryTest < Minitest::Test
     invoice_item_one = @iir.find_all_by_item_id(263519841)
     invoice_item_two = @iir.find_all_by_item_id(263519842)
     invoice_item_three = @iir.find_all_by_item_id(263519847)
+
     assert_equal 263519841, invoice_item_one.first.item_id
     assert_equal 263519842, invoice_item_two.first.item_id
     assert_equal 263519842, invoice_item_two[-1].item_id
@@ -66,6 +69,7 @@ class InvoiceItemRepositoryTest < Minitest::Test
     invoice_items_one = @iir.find_all_by_invoice_id(1)
     invoice_items_two = @iir.find_all_by_invoice_id(2)
     invoice_items_three = @iir.find_all_by_invoice_id(5)
+
     assert_equal 1, invoice_items_one.first.invoice_id
     assert_equal 2, invoice_items_two.first.invoice_id
     assert_equal 2, invoice_items_two[-1].invoice_id
@@ -83,9 +87,9 @@ class InvoiceItemRepositoryTest < Minitest::Test
                     quantity: 4,
                     unit_price: 2134,
                     created_at: '2018-07-28',
-                    updated_at: '2018-07-28'
-                  }
+                    updated_at: '2018-07-28' }
     invoice_item = @iir.create(attributes)
+
     assert_equal 4, invoice_item.id
     assert_equal 27, invoice_item.item_id
     assert_equal 2772, invoice_item.invoice_id
@@ -96,14 +100,13 @@ class InvoiceItemRepositoryTest < Minitest::Test
   end
 
   def test_it_can_update_invoice_item
-    attributes = {
-      quantity: 4,
-      unit_price: 15635
-    }
+    attributes = { quantity: 4,
+                   unit_price: 15635 }
     id = 1
     invoice_item = @iir.update(id, attributes)
     expected = @iir.find_by_id(id)
-    assert_instance_of Time, invoice_item.updated_at # maybe refactor later
+
+    assert_instance_of Time, invoice_item.updated_at
     assert_equal 1, expected.invoice_id
     assert_equal 4, expected.quantity
     assert_equal 15635, expected.unit_price
@@ -111,8 +114,7 @@ class InvoiceItemRepositoryTest < Minitest::Test
 
   def test_it_can_delete_invoice
     id = 2
-
-    invoice = @iir.delete(id)
+    @iir.delete(id)
     expected = @iir.find_by_id(2)
 
     assert_nil expected

--- a/test/invoice_item_repository_test.rb
+++ b/test/invoice_item_repository_test.rb
@@ -53,23 +53,23 @@ class InvoiceItemRepositoryTest < Minitest::Test
   end
 
   def test_it_can_find_all_by_item_id
-    invoice_item_1 = @iir.find_all_by_item_id(263519841)
-    invoice_item_2 = @iir.find_all_by_item_id(263519842)
-    invoice_item_3 = @iir.find_all_by_item_id(263519847)
-    assert_equal 263519841, invoice_item_1.first.item_id
-    assert_equal 263519842, invoice_item_2.first.item_id
-    assert_equal 263519842, invoice_item_2[-1].item_id
-    assert_equal ([]), invoice_item_3
+    invoice_item_one = @iir.find_all_by_item_id(263519841)
+    invoice_item_two = @iir.find_all_by_item_id(263519842)
+    invoice_item_three = @iir.find_all_by_item_id(263519847)
+    assert_equal 263519841, invoice_item_one.first.item_id
+    assert_equal 263519842, invoice_item_two.first.item_id
+    assert_equal 263519842, invoice_item_two[-1].item_id
+    assert_equal [], invoice_item_three
   end
 
   def test_it_can_find_all_invoice_items_by_invoice_id
-    invoice_items_1 = @iir.find_all_by_invoice_id(1)
-    invoice_items_2 = @iir.find_all_by_invoice_id(2)
-    invoice_items_3 = @iir.find_all_by_invoice_id(5)
-    assert_equal 1, invoice_items_1.first.invoice_id
-    assert_equal 2, invoice_items_2.first.invoice_id
-    assert_equal 2, invoice_items_2[-1].invoice_id
-    assert_equal ([]), invoice_items_3
+    invoice_items_one = @iir.find_all_by_invoice_id(1)
+    invoice_items_two = @iir.find_all_by_invoice_id(2)
+    invoice_items_three = @iir.find_all_by_invoice_id(5)
+    assert_equal 1, invoice_items_one.first.invoice_id
+    assert_equal 2, invoice_items_two.first.invoice_id
+    assert_equal 2, invoice_items_two[-1].invoice_id
+    assert_equal [], invoice_items_three
   end
 
   def test_it_can_create_new_id

--- a/test/invoice_item_repository_test.rb
+++ b/test/invoice_item_repository_test.rb
@@ -26,7 +26,15 @@ class InvoiceItemRepositoryTest < Minitest::Test
           unit_price: 33635,
           created_at: '2003-03-03 14:54:09 UTC',
           updated_at: '2013-03-03 14:54:09 UTC' }]
+
     @iir = InvoiceItemRepository.new(@invoice_items)
+
+    @attributes = { item_id: 27,
+                    invoice_id: 2772,
+                    quantity: 4,
+                    unit_price: 2134,
+                    created_at: '2018-07-28',
+                    updated_at: '2018-07-28' }
   end
 
   def test_it_exists
@@ -82,13 +90,7 @@ class InvoiceItemRepositoryTest < Minitest::Test
   end
 
   def test_it_can_create_new_invoice_item
-    attributes = {  item_id: 27,
-                    invoice_id: 2772,
-                    quantity: 4,
-                    unit_price: 2134,
-                    created_at: '2018-07-28',
-                    updated_at: '2018-07-28' }
-    invoice_item = @iir.create(attributes)
+    invoice_item = @iir.create(@attributes)
 
     assert_equal 4, invoice_item.id
     assert_equal 27, invoice_item.item_id

--- a/test/invoice_item_test.rb
+++ b/test/invoice_item_test.rb
@@ -1,20 +1,15 @@
-require_relative '../lib/invoice_item'
 require_relative './test_helper'
+require './lib/invoice_item'
 
 class InvoiceItemTest < Minitest::Test
-
   def setup
-    @invoice_item = InvoiceItem.new(
-      {
-        id: 1,
-        item_id: 263519844,
-        invoice_id: 1,
-        quantity: 5,
-        unit_price: 13635,
-        created_at: '2012-03-27 14:54:09 UTC',
-        updated_at: '2012-03-27 14:54:09 UTC'
-      }
-    )
+    @invoice_item = InvoiceItem.new(id: 1,
+                                    item_id: 263519844,
+                                    invoice_id: 1,
+                                    quantity: 5,
+                                    unit_price: 13635,
+                                    created_at: '2012-03-27 14:54:09 UTC',
+                                    updated_at: '2012-03-27 14:54:09 UTC')
   end
 
   def test_it_exists
@@ -24,5 +19,4 @@ class InvoiceItemTest < Minitest::Test
   def test_it_can_find_unit_price_to_dollars
     assert_equal 136.35, @invoice_item.unit_price_to_dollars
   end
-
 end

--- a/test/invoice_repository_test.rb
+++ b/test/invoice_repository_test.rb
@@ -25,6 +25,12 @@ class InvoiceRepositoryTest < Minitest::Test
          updated_at: '2011-03-04' }]
 
     @invoice_repository = InvoiceRepository.new(@invoices)
+
+    @attributes = { customer_id: 27,
+                    merchant_id: 2772,
+                    status: 'shipping',
+                    created_at: '2010-12-10',
+                    updated_at: '2011-12-04' }
   end
 
   def test_it_exist
@@ -57,7 +63,7 @@ class InvoiceRepositoryTest < Minitest::Test
     assert_equal 1, invoices_one.first.customer_id
     assert_equal 2, invoices_two.first.customer_id
     assert_equal 2, invoices_two[-1].customer_id
-    assert_equal ([]), invoices_three
+    assert_equal [], invoices_three
   end
 
   def test_it_can_find_all_invoices_by_merchant_id
@@ -67,7 +73,7 @@ class InvoiceRepositoryTest < Minitest::Test
     assert_equal 1111, invoices_one.first.merchant_id
     assert_equal 2222, invoices_two.first.merchant_id
     assert_equal 2222, invoices_two[-1].merchant_id
-    assert_equal ([]), invoices_three
+    assert_equal [], invoices_three
   end
 
   def test_it_can_find_all_invoices_by_status
@@ -77,7 +83,7 @@ class InvoiceRepositoryTest < Minitest::Test
     assert_equal :shipped, invoices_one.first.status
     assert_equal :pending, invoices_two.first.status
     assert_equal :pending, invoices_two[-1].status
-    assert_equal ([]), invoices_three
+    assert_equal [], invoices_three
   end
 
   def test_it_can_create_new_id
@@ -86,13 +92,8 @@ class InvoiceRepositoryTest < Minitest::Test
   end
 
   def test_it_can_create_new_invoice
-    attributes = {  customer_id: 27,
-                    merchant_id: 2772,
-                    status: 'shipping',
-                    created_at: '2010-12-10',
-                    updated_at: '2011-12-04',
-                  }
-    invoice = @invoice_repository.create(attributes)
+    invoice = @invoice_repository.create(@attributes)
+
     assert_equal 4, invoice.id
     assert_equal 27, invoice.customer_id
     assert_equal 2772, invoice.merchant_id
@@ -111,13 +112,12 @@ class InvoiceRepositoryTest < Minitest::Test
     assert_instance_of Time, invoice.updated_at # maybe refactor later
     assert_equal 1111, expected.merchant_id
     expected = @invoice_repository.find_all_by_status('shipped')
-    assert_equal ([]), expected
+    assert_equal [], expected
   end
 
   def test_it_can_delete_invoice
     id = 2
-
-    invoice = @invoice_repository.delete(id)
+    @invoice_repository.delete(id)
     expected = @invoice_repository.find_by_id(2)
 
     assert_nil expected

--- a/test/invoice_repository_test.rb
+++ b/test/invoice_repository_test.rb
@@ -51,33 +51,33 @@ class InvoiceRepositoryTest < Minitest::Test
   end
 
   def test_it_can_find_all_invoices_by_customer_id
-    invoices_1 = @invoice_repository.find_all_by_customer_id(1)
-    invoices_2 = @invoice_repository.find_all_by_customer_id(2)
-    invoices_3 = @invoice_repository.find_all_by_customer_id(3)
-    assert_equal 1, invoices_1.first.customer_id
-    assert_equal 2, invoices_2.first.customer_id
-    assert_equal 2, invoices_2[-1].customer_id
-    assert_equal ([]), invoices_3
+    invoices_one = @invoice_repository.find_all_by_customer_id(1)
+    invoices_two = @invoice_repository.find_all_by_customer_id(2)
+    invoices_three = @invoice_repository.find_all_by_customer_id(3)
+    assert_equal 1, invoices_one.first.customer_id
+    assert_equal 2, invoices_two.first.customer_id
+    assert_equal 2, invoices_two[-1].customer_id
+    assert_equal ([]), invoices_three
   end
 
   def test_it_can_find_all_invoices_by_merchant_id
-    invoices_1 = @invoice_repository.find_all_by_merchant_id(1111)
-    invoices_2 = @invoice_repository.find_all_by_merchant_id(2222)
-    invoices_3 = @invoice_repository.find_all_by_merchant_id(3333)
-    assert_equal 1111, invoices_1.first.merchant_id
-    assert_equal 2222, invoices_2.first.merchant_id
-    assert_equal 2222, invoices_2[-1].merchant_id
-    assert_equal ([]), invoices_3
+    invoices_one = @invoice_repository.find_all_by_merchant_id(1111)
+    invoices_two = @invoice_repository.find_all_by_merchant_id(2222)
+    invoices_three = @invoice_repository.find_all_by_merchant_id(3333)
+    assert_equal 1111, invoices_one.first.merchant_id
+    assert_equal 2222, invoices_two.first.merchant_id
+    assert_equal 2222, invoices_two[-1].merchant_id
+    assert_equal ([]), invoices_three
   end
 
   def test_it_can_find_all_invoices_by_status
-    invoices_1 = @invoice_repository.find_all_by_status('shipped')
-    invoices_2 = @invoice_repository.find_all_by_status('pending')
-    invoices_3 = @invoice_repository.find_all_by_status('status DNE')
-    assert_equal :shipped, invoices_1.first.status
-    assert_equal :pending, invoices_2.first.status
-    assert_equal :pending, invoices_2[-1].status
-    assert_equal ([]), invoices_3
+    invoices_one = @invoice_repository.find_all_by_status('shipped')
+    invoices_two = @invoice_repository.find_all_by_status('pending')
+    invoices_three = @invoice_repository.find_all_by_status('status DNE')
+    assert_equal :shipped, invoices_one.first.status
+    assert_equal :pending, invoices_two.first.status
+    assert_equal :pending, invoices_two[-1].status
+    assert_equal ([]), invoices_three
   end
 
   def test_it_can_create_new_id

--- a/test/invoice_repository_test.rb
+++ b/test/invoice_repository_test.rb
@@ -1,28 +1,28 @@
-require_relative '../lib/invoice_repository'
-require_relative '../lib/invoice'
 require_relative './test_helper'
+require './lib/invoice_repository'
+require './lib/invoice'
 
 class InvoiceRepositoryTest < Minitest::Test
   def setup
     @invoices =
-      [{id: 1,
-      customer_id: 1,
-      merchant_id: 1111,
-      status: 'shipped',
-      created_at: '2010-11-10',
-      updated_at: '2011-11-04'},
-      {id: 2,
-      customer_id: 2,
-      merchant_id: 2222,
-      status: 'pending',
-      created_at: '2013-12-10',
-      updated_at: '2013-12-04'},
-      {id: 3,
-      customer_id: 2,
-      merchant_id: 2222,
-      status: 'pending',
-      created_at: '2010-03-10',
-      updated_at: '2011-03-04'}]
+      [{ id: 1,
+         customer_id: 1,
+         merchant_id: 1111,
+         status: 'shipped',
+         created_at: '2010-11-10',
+         updated_at: '2011-11-04' },
+       { id: 2,
+         customer_id: 2,
+         merchant_id: 2222,
+         status: 'pending',
+         created_at: '2013-12-10',
+         updated_at: '2013-12-04' },
+       { id: 3,
+         customer_id: 2,
+         merchant_id: 2222,
+         status: 'pending',
+         created_at: '2010-03-10',
+         updated_at: '2011-03-04' }]
 
     @invoice_repository = InvoiceRepository.new(@invoices)
   end

--- a/test/invoice_repository_test.rb
+++ b/test/invoice_repository_test.rb
@@ -109,7 +109,7 @@ class InvoiceRepositoryTest < Minitest::Test
     id = 1
     invoice = @invoice_repository.update(id, attributes)
     expected = @invoice_repository.find_by_id(id)
-    assert_instance_of Time, invoice.updated_at # maybe refactor later
+    assert_instance_of Time, invoice.updated_at
     assert_equal 1111, expected.merchant_id
     expected = @invoice_repository.find_all_by_status('shipped')
     assert_equal [], expected

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -2,29 +2,24 @@ require_relative './test_helper'
 require './lib/invoice'
 
 class InvoiceTest < Minitest::Test
-
   def test_it_exists
-    invoice = Invoice.new(
-      {id: 1,
-      customer_id: 1,
-      merchant_id: 1111,
-      status: 'shipped',
-      created_at: '2010-11-10',
-      updated_at: '2011-11-04'}
-      )
+    invoice = Invoice.new(id: 1,
+                          customer_id: 1,
+                          merchant_id: 1111,
+                          status: 'shipped',
+                          created_at: '2010-11-10',
+                          updated_at: '2011-11-04')
 
     assert_instance_of Invoice, invoice
   end
 
   def test_it_has_attributes
-    invoice = Invoice.new(
-      {id: 1,
-      customer_id: 1,
-      merchant_id: 1111,
-      status: 'shipped',
-      created_at: '2010-11-10',
-      updated_at: '2011-11-04'}
-      )
+    invoice = Invoice.new(id: 1,
+                          customer_id: 1,
+                          merchant_id: 1111,
+                          status: 'shipped',
+                          created_at: '2010-11-10',
+                          updated_at: '2011-11-04')
 
     assert_equal 1, invoice.id
     assert_equal 1, invoice.customer_id
@@ -33,5 +28,4 @@ class InvoiceTest < Minitest::Test
     assert_equal Time, invoice.created_at.class
     assert_equal Time, invoice.updated_at.class
   end
-
 end

--- a/test/item_repository_test.rb
+++ b/test/item_repository_test.rb
@@ -4,49 +4,48 @@ require_relative './test_helper'
 
 class ItemRepositoryTest < Minitest::Test
   def setup
-    @items =
-      [{id: 1,
-      name: 'OneThing',
-      description:'a car thing that does stuff',
-      unit_price: 1500,
-      merchant_id: 1,
-      created_at: '2018-07-22',
-      updated_at: '2018-07-22'},
-      {id: 2,
-      name: 'TwoThing',
-      description:'a bike thing that does stuff',
-      unit_price: 1370,
-      merchant_id: 1,
-      created_at: '2018-07-22',
-      updated_at: '2018-07-22'},
-      {id: 3,
-      name: 'ThreeThing',
-      description:'a scooter thing that does stuff',
-      unit_price: 1500,
-      merchant_id: 2,
-      created_at: '2018-01-22',
-      updated_at: '2018-07-22'},
-      {id: 4,
-      name: 'FourThing',
-      description:'a skateboard thing that does stuff',
-      unit_price: 1300,
-      merchant_id: 2,
-      created_at: '2018-03-22',
-      updated_at: '2018-07-27'},
-      {id: 5,
-      name: 'FiveThing',
-      description:'a boat thing that does stuff',
-      unit_price: 1500,
-      merchant_id: 2,
-      created_at: '2018-02-23',
-      updated_at: '2018-06-22'},
-      {id: 6,
-      name: 'SixThing',
-      description:'a kayak thing that does stuff',
-      unit_price: 12400,
-      merchant_id: 3,
-      created_at: '2018-04-22',
-      updated_at: '2018-07-12'}]
+    @items = [{ id: 1,
+                name: 'OneThing',
+                description: 'a car thing that does stuff',
+                unit_price: 1500,
+                merchant_id: 1,
+                created_at: '2018-07-22',
+                updated_at: '2018-07-22' },
+              { id: 2,
+                name: 'TwoThing',
+                description: 'a bike thing that does stuff',
+                unit_price: 1370,
+                merchant_id: 1,
+                created_at: '2018-07-22',
+                updated_at: '2018-07-22' },
+              { id: 3,
+                name: 'ThreeThing',
+                description: 'a scooter thing that does stuff',
+                unit_price: 1500,
+                merchant_id: 2,
+                created_at: '2018-01-22',
+                updated_at: '2018-07-22' },
+              { id: 4,
+                name: 'FourThing',
+                description: 'a skateboard thing that does stuff',
+                unit_price: 1300,
+                merchant_id: 2,
+                created_at: '2018-03-22',
+                updated_at: '2018-07-27' },
+              { id: 5,
+                name: 'FiveThing',
+                description: 'a boat thing that does stuff',
+                unit_price: 1500,
+                merchant_id: 2,
+                created_at: '2018-02-23',
+                updated_at: '2018-06-22' },
+              { id: 6,
+                name: 'SixThing',
+                description: 'a kayak thing that does stuff',
+                unit_price: 12400,
+                merchant_id: 3,
+                created_at: '2018-04-22',
+                updated_at: '2018-07-12' }]
 
     @item_repository = ItemRepository.new(@items)
   end
@@ -91,44 +90,44 @@ class ItemRepositoryTest < Minitest::Test
   end
 
   def test_find_all_items_with_description
-    items_1 = @item_repository.find_all_with_description('bike')
-    items_2 = @item_repository.find_all_with_description('zzzz')
-    items_3 = @item_repository.find_all_with_description('stuff')
-    assert_equal 'a bike thing that does stuff', items_1.first.description
-    assert_equal ([]), items_2
-    assert_equal 'a car thing that does stuff', items_3.first.description
-    assert_equal 'a kayak thing that does stuff', items_3[-1].description
-    assert_equal 6, items_3.count
+    items_one = @item_repository.find_all_with_description('bike')
+    items_two = @item_repository.find_all_with_description('zzzz')
+    items_three = @item_repository.find_all_with_description('stuff')
+    assert_equal 'a bike thing that does stuff', items_one.first.description
+    assert_equal [], items_two
+    assert_equal 'a car thing that does stuff', items_three.first.description
+    assert_equal 'a kayak thing that does stuff', items_three[-1].description
+    assert_equal 6, items_three.count
   end
 
   def test_it_can_find_all_with_price
-    items_1 = @item_repository.find_all_by_price(13)
-    items_2 = @item_repository.find_all_by_price(99)
-    items_3 = @item_repository.find_all_by_price(15)
+    items_one = @item_repository.find_all_by_price(13)
+    items_two = @item_repository.find_all_by_price(99)
+    items_three = @item_repository.find_all_by_price(15)
 
-    assert_equal 13, items_1.first.unit_price.to_i
-    assert_equal ([]), items_2
-    assert_equal 3, items_3.count
+    assert_equal 13, items_one.first.unit_price.to_i
+    assert_equal [], items_two
+    assert_equal 3, items_three.count
   end
 
   def test_it_can_find_all_items_within_a_price_range
-    items_1 = @item_repository.find_all_by_price_in_range(0..13)
-    items_2 = @item_repository.find_all_by_price_in_range(98..99)
-    items_3 = @item_repository.find_all_by_price_in_range(0..125)
+    items_one = @item_repository.find_all_by_price_in_range(0..13)
+    items_two = @item_repository.find_all_by_price_in_range(98..99)
+    items_three = @item_repository.find_all_by_price_in_range(0..125)
 
-    assert_equal 13, items_1.first.unit_price.to_i
-    assert_equal ([]), items_2
-    assert_equal 6, items_3.count
+    assert_equal 13, items_one.first.unit_price.to_i
+    assert_equal [], items_two
+    assert_equal 6, items_three.count
   end
 
   def test_it_can_find_all_items_by_merchant_id
-    items_1 = @item_repository.find_all_by_merchant_id(1)
-    items_2 = @item_repository.find_all_by_merchant_id(99)
-    items_3 = @item_repository.find_all_by_merchant_id(2)
+    items_one = @item_repository.find_all_by_merchant_id(1)
+    items_two = @item_repository.find_all_by_merchant_id(99)
+    items_three = @item_repository.find_all_by_merchant_id(2)
 
-    assert_equal 15, items_1.first.unit_price.to_i
-    assert_equal ([]), items_2
-    assert_equal 3, items_3.count
+    assert_equal 15, items_one.first.unit_price.to_i
+    assert_equal [], items_two
+    assert_equal 3, items_three.count
   end
 
   def test_it_can_find_highest_id
@@ -142,41 +141,38 @@ class ItemRepositoryTest < Minitest::Test
   end
 
   def test_it_can_create_attributes
-    attributes =
-        {name: 'SevenThing',
-        description:'a moped thing that does stuff',
-        unit_price: 3500,
-        merchant_id: 1,
-        created_at: '2018-07-20',
-        updated_at: '2018-07-20'}
+    attributes = { name: 'SevenThing',
+                   description: 'a moped thing that does stuff',
+                   unit_price: 3500,
+                   merchant_id: 1,
+                   created_at: '2018-07-20',
+                   updated_at: '2018-07-20' }
     item = @item_repository.create(attributes)
     assert_equal 'SevenThing', item[-1].name
     assert_equal 7, item[-1].id
   end
 
   def test_it_can_update_item_attributes
-    attributes = {
-      name: 'ShinySixThing' ,
-      description: 'a new shiny kayak thing that does stuff',
-      unit_price: 20000,
-    }
+    attributes = { name: 'ShinySixThing',
+                   description: 'a new shiny kayak thing that does stuff',
+                   unit_price: 20000 }
     id = 6
-    item = @item_repository.update(id, attributes)
-    expected_1 = @item_repository.find_by_id(id)
-    assert_equal 'ShinySixThing', expected_1.name
-    assert_equal Time, expected_1.updated_at.class
-    expected_2 = @item_repository.find_by_name('SixThing')
-    assert_nil expected_2
+    @item_repository.update(id, attributes)
+    expected_one = @item_repository.find_by_id(id)
+    assert_equal 'ShinySixThing', expected_one.name
+    assert_equal Time, expected_one.updated_at.class
+    expected_two = @item_repository.find_by_name('SixThing')
+    assert_nil expected_two
   end
 
   def test_it_can_delete_an_item
     id = 4
 
-    item = @item_repository.delete(id)
-    expected_1 = @item_repository.find_by_name('FourThing')
-    expected_2 = @item_repository.find_by_id(id)
+    @item_repository.delete(id)
+    expected_one = @item_repository.find_by_name('FourThing')
+    expected_two = @item_repository.find_by_id(id)
 
-    assert_nil expected_1
-    assert_nil expected_2
+    assert_nil expected_one
+    assert_nil expected_two
   end
 end

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -2,20 +2,15 @@ require_relative './test_helper'
 require './lib/item'
 require 'bigdecimal'
 
-
 class ItemTest < Minitest::Test
-
   def setup
-    @info = {
-      id:          1,
-      name:        "Pencil",
-      description: "You can use it to write things",
-      unit_price:  "1200",
-      created_at:  Time.now,
-      updated_at:  Time.now,
-      merchant_id: 2
-    }
-
+    @info = { id: 1,
+              name: 'Pencil',
+              description: 'You can use it to write things',
+              unit_price: '1200',
+              created_at: Time.now,
+              updated_at: Time.now,
+              merchant_id: 2 }
   end
 
   def test_it_exists
@@ -28,8 +23,8 @@ class ItemTest < Minitest::Test
     item = Item.new(@info)
 
     assert_equal 1, item.id
-    assert_equal "Pencil", item.name
-    assert_equal "You can use it to write things", item.description
+    assert_equal 'Pencil', item.name
+    assert_equal 'You can use it to write things', item.description
     assert_equal 12, item.unit_price.to_i
     assert_equal Time, item.created_at.class
     assert_equal Time, item.updated_at.class
@@ -41,6 +36,4 @@ class ItemTest < Minitest::Test
 
     assert_equal 12.00, item.unit_price_to_dollars
   end
-
-
 end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -1,22 +1,21 @@
-require_relative '../lib/merchant_repository'
-require_relative '../lib/merchant'
 require_relative './test_helper'
+require './lib/merchant_repository'
+require './lib/merchant'
 
 class MerchantRepositoryTest < Minitest::Test
   def setup
-    @merchants =
-      [{id: 12334105,
-      name: 'Shopin1901',
-      created_at: '2010-12-10',
-      updated_at: '2011-12-04'},
-      {id: 12334112,
-      name: 'Candisart',
-      created_at: '2009-05-30',
-      updated_at: '2010-08-29'},
-      {id: 12334113,
-      name: 'MiniatureBikez',
-      created_at: '2010-03-30',
-      updated_at: '2013-01-21'}]
+    @merchants = [{ id: 12334105,
+                    name: 'Shopin1901',
+                    created_at: '2010-12-10',
+                    updated_at: '2011-12-04' },
+                  { id: 12334112,
+                    name: 'Candisart',
+                    created_at: '2009-05-30',
+                    updated_at: '2010-08-29' },
+                  { id: 12334113,
+                    name: 'MiniatureBikez',
+                    created_at: '2010-03-30',
+                    updated_at: '2013-01-21' }]
 
     @merchant_repository = MerchantRepository.new(@merchants)
   end
@@ -61,13 +60,13 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def test_find_all_by_name_or_name_fragment
-    merchants_1 = @merchant_repository.find_all_by_name('Bike')
-    merchants_2 = @merchant_repository.find_all_by_name('zzzz')
-    merchants_3 = @merchant_repository.find_all_by_name('in')
-    assert_equal 'MiniatureBikez', merchants_1.first.name
-    assert_equal ([]), merchants_2
-    assert_equal 'Shopin1901', merchants_3.first.name
-    assert_equal 'MiniatureBikez', merchants_3[-1].name
+    merchants_one = @merchant_repository.find_all_by_name('Bike')
+    merchants_two = @merchant_repository.find_all_by_name('zzzz')
+    merchants_three = @merchant_repository.find_all_by_name('in')
+    assert_equal 'MiniatureBikez', merchants_one.first.name
+    assert_equal ([]), merchants_two
+    assert_equal 'Shopin1901', merchants_three.first.name
+    assert_equal 'MiniatureBikez', merchants_three[-1].name
   end
 
   def test_it_can_find_highest_id
@@ -81,10 +80,9 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def test_it_can_create_new_merchant
-    attributes = {  name: 'Turing School',
-                    created_at: '2010-12-10',
-                    updated_at: '2011-12-04'
-                  }
+    attributes = { name: 'Turing School',
+                   created_at: '2010-12-10',
+                   updated_at: '2011-12-04' }
     merchant = @merchant_repository.create(attributes)
     assert_equal 'Turing School', merchant.name
     assert_equal 12334114, merchant.id
@@ -95,7 +93,7 @@ class MerchantRepositoryTest < Minitest::Test
       name: 'Shopin2001'
     }
     id = 12334105
-    merchant = @merchant_repository.update(id, attributes)
+    @merchant_repository.update(id, attributes)
     expected = @merchant_repository.find_by_id(id)
     assert_equal 'Shopin2001', expected.name
     expected = @merchant_repository.find_by_name('Shopin1901')
@@ -105,11 +103,11 @@ class MerchantRepositoryTest < Minitest::Test
   def test_it_can_delete_merchant
     id = 12334105
 
-    merchant = @merchant_repository.delete(id)
-    expected_1 = @merchant_repository.find_by_name('Shopin1901')
-    expected_2 = @merchant_repository.find_by_id(id)
+    @merchant_repository.delete(id)
+    expected_one = @merchant_repository.find_by_name('Shopin1901')
+    expected_two = @merchant_repository.find_by_id(id)
 
-    assert_nil expected_1
-    assert_nil expected_2
+    assert_nil expected_one
+    assert_nil expected_two
   end
 end

--- a/test/merchant_test.rb
+++ b/test/merchant_test.rb
@@ -2,32 +2,22 @@ require_relative './test_helper'
 require './lib/merchant'
 
 class MerchantTest < Minitest::Test
-
   def test_it_exists
-    merchant = Merchant.new(
-      {
-        :id => 5,
-        :name => "Turing School",
-        :created_at => "2010-12-10",
-        :updated_at => "2011-12-04"
-        }
-      )
+    merchant = Merchant.new(id: 5,
+                            name: 'Turing School',
+                            created_at: '2010-12-10',
+                            updated_at: '2011-12-04')
 
     assert_instance_of Merchant, merchant
   end
 
   def test_it_has_attributes
-    merchant = Merchant.new(
-      {
-        :id => 5,
-        :name => "Turing School",
-        :created_at => "2010-12-10",
-        :updated_at => "2011-12-04"
-        }
-      )
+    merchant = Merchant.new(id: 5,
+                            name: 'Turing School',
+                            created_at: '2010-12-10',
+                            updated_at: '2011-12-04')
 
     assert_equal 5, merchant.id
-    assert_equal "Turing School", merchant.name
+    assert_equal 'Turing School', merchant.name
   end
-
 end

--- a/test/sales_analyst_test.rb
+++ b/test/sales_analyst_test.rb
@@ -3,16 +3,12 @@ require './lib/sales_analyst'
 require './lib/sales_engine'
 
 class SalesAnalystTest < Minitest::Test
-
   def setup
-    @se = SalesEngine.from_csv({
-      :items     =>  "./data/fake_item_csv.csv",
-      # "./data/items.csv",
-      :merchants => "./data/fake_merchant_csv.csv",
-      :invoices => "./data/fake_invoice_csv.csv",
-      :transactions => "./data/fake_transaction_csv.csv",
-      :invoice_items => "./data/fake_invoice_items_csv.csv"
-    })
+    @se = SalesEngine.from_csv(items:  './data/fake_item_csv.csv',
+                               merchants: './data/fake_merchant_csv.csv',
+                               invoices: './data/fake_invoice_csv.csv',
+                               transactions: './data/fake_transaction_csv.csv',
+                               invoice_items: './data/fake_invoice_items_csv.csv')
 
     @sa = SalesAnalyst.new(@se)
   end
@@ -39,13 +35,11 @@ class SalesAnalystTest < Minitest::Test
   end
 
   def test_it_can_find_average_items_per_merchant
-    # ((1/1)+(2/1)+(3/1)+(4/1)+(3/1))/5 = 13/5 = 2.6 avg
     assert_equal 2.6, @sa.average_items_per_merchant
     assert_equal Float, @sa.average_items_per_merchant.class
   end
 
   def test_it_can_find_average_items_per_merchant_standard_deviation
-    # sqrt(((1-2.6)^2+(2-2.6)^2+(3-2.6)^2+(4-2.6)^2+(3-2.6)^2)/4) = 1.14 sd
     assert_equal 1.14, @sa.average_items_per_merchant_standard_deviation
     assert_equal Float, @sa.average_items_per_merchant_standard_deviation.class
   end
@@ -67,7 +61,6 @@ class SalesAnalystTest < Minitest::Test
   end
 
   def test_it_can_find_one_stnd_deviation_above_average
-    # avg + sd = 2.60 + 1.14 = 3.74
     assert_equal 3.74, @sa.items_one_standard_deviation_above
   end
 
@@ -90,7 +83,6 @@ class SalesAnalystTest < Minitest::Test
   end
 
   def test_it_can_find_average_average_price_per_merchant
-  # (9/1 + (10+11)/2 + (12+13+14)/3 + (15+16+17+18)/4 + (19+20+50)/3)/5 = 15.73
     assert_equal 15.73, @sa.average_average_price_per_merchant
     assert_equal BigDecimal, @sa.average_average_price_per_merchant.class
   end
@@ -101,7 +93,6 @@ class SalesAnalystTest < Minitest::Test
   end
 
   def test_it_can_find_item_price_average
-    # (9+10+11+12+13+14+15+16+17+18+19+20+50)/13 = 17.23
     assert_equal 17.23, @sa.item_price_average
   end
 
@@ -110,18 +101,12 @@ class SalesAnalystTest < Minitest::Test
   end
 
   def test_it_can_find_standard_deviation_for_item_price
-    # sqrt(((9-17.23)^2 +(10-17.23)^2 +(11-17.23)^2 +(12-17.23)^2+(13-17.23)^2 + (14-17.23)^2+(15-17.23)^2+(16-17.23)^2+(17-17.23)^2+(18-17.23)^2+(19-17.23)^2+(20-17.23)^2+(50-17.23)^2)/12) = 10.43
     assert_equal 10.43, @sa.standard_deviation_for_item_price
   end
 
   def test_it_can_find_golden_items
-    # items where price >= $38.09 or 2 standard deviations above average price
     assert_equal 1, @sa.golden_items.count
-    # assert_equal Item, @sa.golden_items.class
   end
-
-
-  #--------------------------ITERATION-2-STUFF-------------#
 
   def test_it_can_group_invoices_by_merchant_id
     assert_equal 1, @sa.group_invoices_by_merchant[1].count
@@ -139,47 +124,31 @@ class SalesAnalystTest < Minitest::Test
 
   def test_it_can_find_average_invoices_per_merchant_standard_deviation
     assert_equal 1.14, @sa.average_invoices_per_merchant_standard_deviation
-    assert_equal Float, @sa.average_invoices_per_merchant_standard_deviation.class
+    actual = @sa.average_invoices_per_merchant_standard_deviation.class
+    assert_equal Float, actual
   end
 
   def test_it_can_find_number_of_invoices_for_each_merchant
     assert_equal [1, 2, 3, 4, 3], @sa.invoices_per_merchant
   end
 
-  def test_it_can_find_variance
-    invoice_count_array = [2, 3, 4, 3, 5]
-    average = 3.4
-    assert_equal 5.2, @sa.variance(average, invoice_count_array)
-  end
-
-  def test_it_can_find_square_root_of_variance
-    variance = 5.2
-    invoices_per_merchant = [2, 3, 4, 3, 5]
-    assert_equal 1.14, @sa.square_root_of_variance(variance, invoices_per_merchant)
-  end
-
   def test_it_can_find_invoices_two_standard_deviations_above_average
     assert_equal 4.88, @sa.invoices_two_standard_deviations_above
   end
 
-  def test_it_groups_top_merchants_by_invoice_count_over_two_standard_deviations # > 2sd above avg
+  def test_it_groups_top_merchants_by_invoice_count_over_two_standard_deviations
     assert_equal 0, @sa.top_merchants_by_invoice_count.count
-    assert_equal ([]), @sa.bottom_merchants_by_invoice_count
+    assert_equal [], @sa.bottom_merchants_by_invoice_count
   end
 
   def test_it_can_find_two_standard_deviations_below_average
     assert_equal 0.32, @sa.invoices_two_standard_deviations_below
   end
 
-  def test_it_groups_bottom_merchants_by_invoice_count_below_two_standard_deviations
+  def test_it_finds_bottom_merchants_by_invoice_count_below_two_std_devs
     assert_equal 0, @sa.bottom_merchants_by_invoice_count.count
-    assert_equal ([]), @sa.bottom_merchants_by_invoice_count
+    assert_equal [], @sa.bottom_merchants_by_invoice_count
   end
-# On which days are invoices created at more than one standard deviation above the mean?
-
-  # def test_it_can_convert_numerical_date_to_week_day
-  #   assert_equal "Saturday", @sa.weekday("2018-07-28")
-  # end
 
   def test_it_can_group_invoices_by_date
     assert_equal 7, @sa.group_invoices_by_day_created.count
@@ -216,7 +185,7 @@ class SalesAnalystTest < Minitest::Test
 
   def test_it_groups_top_days_by_invoice_count_over_one_standard_deviation
     assert_equal 1, @sa.top_days_by_invoice_count.count
-    assert_equal (["Sunday"]), @sa.top_days_by_invoice_count
+    assert_equal ['Sunday'], @sa.top_days_by_invoice_count
   end
 
   def test_it_can_find_percentage_of_invoices
@@ -227,7 +196,8 @@ class SalesAnalystTest < Minitest::Test
 
   def test_it_can_group_invoices_by_status
     assert_equal 3, @sa.group_invoices_by_status.count
-    expected = ([:returned,:shipped,:pending])
+    expected = [:returned, :shipped, :pending]
+
     assert_equal expected, @sa.group_invoices_by_status.keys
     assert_equal 1, @sa.group_invoices_by_status[:returned].count
     assert_equal 7, @sa.group_invoices_by_status[:shipped].count
@@ -263,10 +233,6 @@ class SalesAnalystTest < Minitest::Test
     assert_equal 2, @sa.top_revenue_earners(2).last.id
   end
 
-  # def test_can_get_invoice_ids
-  #   assert_equal [1,2,3,4,5,6], @sa.get_invoice_ids
-  # end
-
   def test_invoice_hash
     assert_equal Array, @sa.invoice_hash[1].class
     assert_equal 1, @sa.invoice_hash[1].count
@@ -300,7 +266,7 @@ class SalesAnalystTest < Minitest::Test
 
   def test_it_can_collect_merchant_ids_with_one_item
     assert_equal 1, @sa.get_merchant_ids_with_one_item.count
-    assert_equal ({1 => 1}), @sa.get_merchant_ids_with_one_item
+    assert_equal ({ 1 => 1 }), @sa.get_merchant_ids_with_one_item
   end
 
   def test_groups_merchants_with_only_one_item
@@ -309,7 +275,7 @@ class SalesAnalystTest < Minitest::Test
   end
 
   def test_it_can_group_merchants_with_one_item_by_month_created_at
-    actual = @sa.merchants_with_only_one_item_registered_in_month("December")
+    actual = @sa.merchants_with_only_one_item_registered_in_month('December')
     assert_equal 1, actual.count
     assert_equal Merchant, actual.first.class
   end
@@ -319,10 +285,10 @@ class SalesAnalystTest < Minitest::Test
     assert_equal BigDecimal, @sa.revenue_by_merchant(1).class
   end
 
-  def test_can_find_a_merchants_most_sold_item #=> [item]
+  def test_can_find_a_merchants_most_sold_item
     assert_equal Array, @sa.most_sold_item_for_merchant(4).class
     assert_equal Item, @sa.most_sold_item_for_merchant(4).first.class
-    assert_equal "NineThing", @sa.most_sold_item_for_merchant(4).first.name
+    assert_equal 'NineThing', @sa.most_sold_item_for_merchant(4).first.name
     assert_equal 1, @sa.most_sold_item_for_merchant(4).count
   end
 
@@ -331,9 +297,6 @@ class SalesAnalystTest < Minitest::Test
     assert_equal Invoice, @sa.pull_paid_invoices_per_merchant(4).first.class
     assert_equal 7, @sa.pull_paid_invoices_per_merchant(4).first.id
     assert_equal 9, @sa.pull_paid_invoices_per_merchant(4).last.id
-    # [invoice_1, invoice_2]
-    # invoice_1 = #<Invoice:0xXXXXXX @id=7, @customer_id=1, @merchant_id=4, @status=:pending, @created_at=2018-07-28 00:00:00-0600, @updated_at=2018-08-26 00:00:00 -0600>
-    # invoice_2 = #<Invoice:0xXXXXXX @id=9, @customer_id=2, @merchant_id=4, @status=:shipped, @created_at=2018-08-03 00:00:00 -0600, @updated_at=2018-11-05 00:00:00 -0700>
   end
 
   def test_it_can_find_all_paid_invoice_items_by_invoice_id
@@ -343,9 +306,6 @@ class SalesAnalystTest < Minitest::Test
     assert_equal 7, @sa.find_all_paid_invoice_items_by_id(paid_invoices).first.invoice_id
     assert_equal 9, @sa.find_all_paid_invoice_items_by_id(paid_invoices).last.invoice_id
     assert_equal InvoiceItem, @sa.find_all_paid_invoice_items_by_id(paid_invoices).first.class
-    # [item_1, item_2]
-    #item 1 = #<InvoiceItem:0xXXXXXX @id=7, @item_id=7, @invoice_id=7, @quantity=4, @unit_price=#<BigDecimal:7f8c85064960,'0.66747E3',18(36)>, @created_at=2012-03-27 14:54:09 UTC, @updated_at=2012-03-27 14:54:09 UTC>
-    #item 2 = #<InvoiceItem:0xXXXXXX @id=9, @item_id=9, @invoice_id=9, @quantity=6, @unit_price=#<BigDecimal:7f818a83c918,'0.29973E3',18(36)>, @created_at=2012-03-27 14:54:09 UTC, @updated_at=2012-03-27 14:54:09 UTC>
   end
 
   def test_it_can_find_invoice_item_quantities_sold_by_merchant
@@ -353,9 +313,8 @@ class SalesAnalystTest < Minitest::Test
     paid_invoice_items = @sa.find_all_paid_invoice_items_by_id(paid_invoices)
 
     assert_equal 2, @sa.sold_invoice_item_quantities(paid_invoice_items).count
-    assert_equal ({7=>4, 9=>6}), @sa.sold_invoice_item_quantities(paid_invoice_items)
+    assert_equal ({ 7 => 4, 9 => 6 }), @sa.sold_invoice_item_quantities(paid_invoice_items)
   end
-
 
   def test_it_can_find_a_merchants_best_selling_item_by_quantity
     paid_invoices = @sa.pull_paid_invoices_per_merchant(4)
@@ -364,32 +323,27 @@ class SalesAnalystTest < Minitest::Test
 
     assert_equal Array, @sa.top_selling_item_by_quantity(quantities).class
     assert_equal Item, @sa.top_selling_item_by_quantity(quantities).first.class
-    assert_equal "NineThing", @sa.top_selling_item_by_quantity(quantities).first.name
+    assert_equal 'NineThing', @sa.top_selling_item_by_quantity(quantities).first.name
     assert_equal 1, @sa.top_selling_item_by_quantity(quantities).count
-    #=> [#<Item:0xXXXXXX @id=9, @name="NineThing", @description="a Tesla thing that does stuff", @unit_price=#<BigDecimal:7fe51e8eef30,'0.17E2',9(36)>, @created_at=2018-04-22 00:00:00 -0600, @updated_at=2018-07-12 00:00:00 -0600, @merchant_id=4>]
   end
 
   def test_it_can_find_a_merchants_best_selling_item_by_revenue
-    # assert_equal [], @sa.best_item_for_merchant(4)
     paid_invoices = @sa.pull_paid_invoices_per_merchant(4)
     paid_invoice_items = @sa.find_all_paid_invoice_items_by_id(paid_invoices)
     revenues = @sa.sold_invoice_item_revenues(paid_invoice_items)
 
     assert_equal Array, @sa.top_selling_item_by_revenue(revenues).class
     assert_equal Item, @sa.top_selling_item_by_revenue(revenues).first.class
-    assert_equal "SevenThing", @sa.top_selling_item_by_revenue(revenues).first.name
+    assert_equal 'SevenThing', @sa.top_selling_item_by_revenue(revenues).first.name
     assert_equal 1, @sa.top_selling_item_by_revenue(revenues).count
-    #=> [#<Item:0xXXXXXX @id=7, @name="SevenThing", @description="a longboard thing that does stuff", @unit_price=#<BigDecimal:7f970113e9e0,'0.15E2',9(36)>, @created_at=2018-04-22 00:00:00 -0600, @updated_at=2018-07-12 00:00:00 -0600, @merchant_id=4>]
   end
-
 
   def test_it_can_find_invoice_item_revenues_received_by_merchant
     paid_invoices = @sa.pull_paid_invoices_per_merchant(4)
     paid_invoice_items = @sa.find_all_paid_invoice_items_by_id(paid_invoices)
 
     assert_equal 2, @sa.sold_invoice_item_revenues(paid_invoice_items).count
-    assert_equal [7,9], @sa.sold_invoice_item_revenues(paid_invoice_items).keys
-    #=> {7=>#<BigDecimal:7fed0f8d9678,'0.266988E4',18(36)>, 9=>#<BigDecimal:7fed0f8d95b0,'0.179838E4',18(36)>}
+    assert_equal [7, 9], @sa.sold_invoice_item_revenues(paid_invoice_items).keys
   end
 
   def test_it_can_find_a_merchants_best_selling_item_by_price
@@ -399,10 +353,7 @@ class SalesAnalystTest < Minitest::Test
 
     assert_equal Array, @sa.top_selling_item_by_revenue(revenues).class
     assert_equal Item, @sa.top_selling_item_by_revenue(revenues).first.class
-    assert_equal "NineThing", @sa.top_selling_item_by_revenue(revenues).first.name
+    assert_equal 'NineThing', @sa.top_selling_item_by_revenue(revenues).first.name
     assert_equal 1, @sa.top_selling_item_by_revenue(revenues).count
-    #=> [#<Item:0xXXXXXX @id=9, @name="NineThing", @description="a Tesla thing that does stuff", @unit_price=#<BigDecimal:7fe51e8eef30,'0.17E2',9(36)>, @created_at=2018-04-22 00:00:00 -0600, @updated_at=2018-07-12 00:00:00 -0600, @merchant_id=4>]
   end
-
-
 end


### PR DESCRIPTION
This resolves as many rubo cop errors as possible for all tests except those in file sales_engine_test.rb, test_helper.rb, transaction_repository_test.rb, and transaction_test.rb (which are done in a separate PR).